### PR TITLE
Add wgautomesh

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@
 | [wiresmith](https://github.com/svenstaro/wiresmith) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | Unlimited | :x: | :x: | :x: | :x: | :globe_with_meridians: | :x: | :x: | :x: | :x: | :x: | :x: |
 | [webmesh](https://github.com/webmeshproj/webmesh) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | Unlimited | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :globe_with_meridians: | :globe_with_meridians: | :globe_with_meridians: | :soon: | :soon: | :soon: | :white_check_mark: |
 | [NordVPN Meshnet](https://github.com/NordSecurity/libtelio) | :white_check_mark: [:exclamation:<sup>4<sup>](#nvmexplain1) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :one::zero: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :globe_with_meridians: | :globe_with_meridians: :lock_with_ink_pen: | :globe_with_meridians: :lock_with_ink_pen: | :globe_with_meridians: :lock_with_ink_pen: | :globe_with_meridians: :lock_with_ink_pen: | :soon: | :white_check_mark: |
+| [wgautomesh](https://git.deuxfleurs.fr/Deuxfleurs/wgautomesh) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | Unlimited | :x: | :x: | :x: | :white_check_mark: | :globe_with_meridians: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: |
   
  <sup>0</sup><a name="tsexplain1">Tailscale's client code is open source. Tailscale's control server code is entirely closed source (It's a SaaS product).</a>  
   


### PR DESCRIPTION
Fixes #42
I hope i got right. Since the tool [automatically adds /32 address of the peer](https://git.deuxfleurs.fr/Deuxfleurs/wgautomesh/src/commit/59d315b853d4251dfdfd8229152bc151655da438/src/main.rs#L673) to allowed-ips i'm assuming no full tunnel support. Regarding custom dns... does the DNS section in vanilla wireguard config count? i've read the code and from what i see it shouldn't interfere. it's just `wg set` under the hood.